### PR TITLE
Add support for first_name, last_name, display_name, and avatar_url f…

### DIFF
--- a/lib/layer/identity_token.rb
+++ b/lib/layer/identity_token.rb
@@ -3,8 +3,8 @@ require "jwt"
 module Layer
   class IdentityToken
     class << self
-      attr_writer :layer_provider_id, 
-                  :layer_key_id, 
+      attr_writer :layer_provider_id,
+                  :layer_key_id,
                   :layer_private_key
 
       def layer_provider_id
@@ -20,14 +20,21 @@ module Layer
       end
     end
 
-    attr_reader :user_id, 
-                :nonce, 
-                :expires_at
-    
-    def initialize(user_id, nonce, expires_at = (Time.now+(86400*14)))
+    SUPPORTED_CLAIM_ATTRIBUTES = %w(first_name last_name display_name avatar_url)
+
+    attr_reader :user_id,
+                :nonce,
+                :expires_at,
+                :more_claim_attributes
+
+    def initialize(user_id, nonce, expires_at = (Time.now+(86400*14)),
+                   more_claim_attributes = {})
       @user_id = user_id
       @nonce = nonce
       @expires_at = expires_at
+      @more_claim_attributes = more_claim_attributes.select do |key, _value|
+        SUPPORTED_CLAIM_ATTRIBUTES.include?(key.to_s)
+      end
     end
 
     def encode
@@ -52,13 +59,13 @@ module Layer
     end
 
     def claim
-      {
+      more_claim_attributes.merge(
         iss: self.class.layer_provider_id,
         prn: user_id.to_s,
         iat: Time.now.to_i,
         exp: expires_at.to_i,
         nce: nonce
-      }
+      )
     end
 
     def private_key


### PR DESCRIPTION
…ields as optional arguments to identity token 

@we5, @benedikt, please review.

Current version of the Layer identity token generation includes additional fields in the claim set like `first_name`, `last_name`, `display_name`, and `avatar_url`. This pull adds support for this.

https://developer.layer.com/docs/ios/guides

``` json5
// JWT Claims Set
{
    "iss": "layer:///providers/a36878dc-fd0f-11e5-a886-1df6000000b0", // String - The Layer Provider ID, this is your actual provider ID
    "prn": "APPLICATION USER ID", // String - Provider's internal ID for the authenticating user
    "iat": "TIME OF TOKEN ISSUANCE AS INTEGER", // Integer - Time of Token Issuance in RFC 3339 seconds
    "exp": "TIME OF TOKEN EXPIRATION AS INTEGER", // Integer - Arbitrary time of Token Expiration in RFC 3339 seconds
    "nce": "LAYER ISSUED NONCE" // The nonce obtained via the Layer client SDK.
    "first_name" : "IDENTITY FIRST NAME FOR USER ID" // String - Provider's internal first name.  Optional.
    "last_name" : "IDENTITY LAST NAME FOR USER ID" // String - Provider's internal last name.  Optional.
    "display_name" : "IDENTITY DISPLAY NAME FOR USER ID" // String - Provider's internal display name.  Optional.
    "avatar_url" : "IDENTITY AVATAR URL FOR USER ID" // String - Provider's internal avatar URL. Optional.
}
```
